### PR TITLE
Handler & Message abstraction

### DIFF
--- a/src/Gyoza/IHandler.cs
+++ b/src/Gyoza/IHandler.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace Gyoza
+{
+    /// <summary>
+    /// Define a handler
+    /// </summary>
+    public interface IHandler<in TMessage> where TMessage: IMessage
+    {
+        /// <summary>
+        /// Handle a message
+        /// </summary>
+        /// <param name="message">Message to handle</param>
+        /// <returns>Result</returns>
+        Task<IResult> HandleAsync(TMessage message);
+    }
+}

--- a/src/Gyoza/IMessage.cs
+++ b/src/Gyoza/IMessage.cs
@@ -1,0 +1,10 @@
+namespace Gyoza
+{
+    /// <summary>
+    /// Define a dispatchable message
+    /// </summary>
+    public interface IMessage
+    {
+        
+    }
+}


### PR DESCRIPTION
### Issue
Define an abstraction to handle a message: #15 

### Information
Both interfaces are key principles in Gyoza.

First one is **IMessage**, this interface mark message object to be dispatch and handle by the library. Here is an example of a basic message to delete a user corresponding to an id:

```csharp
public class DeleteUserMessage : IMessage
{
    public int Id { get; set; }
}
```

The second one is **IHandler**. This interface define a constraint to handle an **IMessage** implementation. **HandleAsync** method will do the job in implementation. This method can be used with **async**/**await** and must return a **IResult** implementation. Here is an example of a handler for the previous message: 

```csharp
public class DeleteUserHandler : IHandler<DeleteUserMessage>
{
    public IRepository<User> UserRepository { get; }

    public DeleteUserHandler(IRepository<User> userRepository)
    {
        UserRepository = userRepository;
    }

    public async Task<IResult> HandleAsync(DeleteUserMessagemessage)
    {
        await UserRepository.Delete(message.Id);
        return new Result(State.Success);
    }
}
```

These two interfaces are required for all other development.