### PR TITLE
Message validator

### DIFF
--- a/src/Gyoza/IValidator.cs
+++ b/src/Gyoza/IValidator.cs
@@ -13,6 +13,6 @@ namespace Gyoza
         /// </summary>
         /// <param name="message">Message to validate</param>
         /// <returns>Validation error messages</returns>
-        IEnumerable<(string, string)> Validate(TMessage message);
+        IEnumerable<(string property, string error)> Validate(TMessage message);
     }
 }

--- a/src/Gyoza/IValidator.cs
+++ b/src/Gyoza/IValidator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Gyoza
 {
@@ -13,6 +14,6 @@ namespace Gyoza
         /// </summary>
         /// <param name="message">Message to validate</param>
         /// <returns>Validation error messages</returns>
-        IEnumerable<(string property, string error)> Validate(TMessage message);
+        Task<IEnumerable<(string property, string error)>> ValidateAsync(TMessage message);
     }
 }

--- a/src/Gyoza/IValidator.cs
+++ b/src/Gyoza/IValidator.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace Gyoza
+{
+    /// <summary>
+    /// Define a message validator
+    /// </summary>
+    public interface IValidator<in TMessage>
+        where TMessage : IMessage
+    {
+        /// <summary>
+        /// Validate a message
+        /// </summary>
+        /// <param name="message">Message to validate</param>
+        /// <returns>Validation error messages</returns>
+        IEnumerable<(string, string)> Validate(TMessage message);
+    }
+}


### PR DESCRIPTION
### Issue
Add an abstraction to validate message: #16   

### Information
**IValidation** contains a basic Validate method to deal with mesage validation. The interface define a constrains on message to be an implementations of **IMessage**. The validation method can be used asynchronously and return an enumeration of tuple which contains property and error informations for each validation error.

A quick example of **IValidation** implementation with an object which contains an identifier property:

```csharp
public class DeleteUserMessage : IMessage
{
    public int Id { get; set; }
}

public class DeleteUserMessageValidator : IValidator<DeleteUserMessage>
{
    public async Task<IEnumerable<(string property, string error)>>ValidateAsync(DeleteUserMessage message)
    {
        var errors = new List<(string property, string error)>();
        if(message.Id <= 0)
            errors.Add((nameof(message.Id), "Identifier must be greater than 0"));

        return await Task.FromResult(errors);
    }
}
```